### PR TITLE
End the stream after the messages are sent.

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -48,12 +48,20 @@ function streamingResponse(call) {
       Math.floor(Math.random() * maxTimeout)
     );
   }
+
+  setTimeout(() => {
+    call.end()
+  }, maxTimeout + 10)
 }
 
 function bidirectionalStreaming(call) {
   call.on('data', data => {
     call.write(data);
   });
+
+  call.on('end', () => {
+    call.end();
+  })
 }
 
 function enumRequest(call, callback) {


### PR DESCRIPTION
The endless stream caused issues when running tests because the grpc client would never exit.
This is no beautiful solution but it should do the trick
